### PR TITLE
chore: align pre-commit checks with dotfiles

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,7 +25,10 @@ jobs:
           bash -n setup.sh uninstall.sh
           ./setup.sh --help
           ./uninstall.sh --help
-          ! grep -Eq '^brew "(rust|node|fd)"' Brewfile
+          if grep -Eq '^brew "(rust|node|fd)"' Brewfile; then
+            echo "Brewfile contains a removed dependency." >&2
+            exit 1
+          fi
           grep -q '^brew "bun"' Brewfile
           grep -q '^brew "neovim"' Brewfile
 
@@ -96,7 +99,7 @@ jobs:
             eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           fi
           ./uninstall.sh
-          ! test -L "$HOME/.zshrc"
-          ! test -L "$HOME/.config/nvim"
+          test ! -L "$HOME/.zshrc"
+          test ! -L "$HOME/.config/nvim"
           brew list --formula neovim
           brew list --formula bun

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,15 @@ repos:
       - id: check-json
         stages: [pre-commit]
       - id: check-added-large-files
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
     hooks:
-      - id: ruff
-        types_or: [python, pyi]
-        args: [--fix]
-      - id: ruff-format
-        types_or: [python, pyi]
-        stages: [pre-commit]
+      - id: shellcheck
+        exclude: ^\.zshrc$
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
     hooks:


### PR DESCRIPTION
Replace the inherited Python Ruff hooks with checks that match this repository: ShellCheck for Bash scripts and actionlint for GitHub Actions workflows. Zsh configuration is excluded from ShellCheck because ShellCheck does not support Zsh syntax. Existing file hygiene and Conventional Commit hooks remain unchanged.