### PR TITLE
chore: Lualineのextension設定を整理

### DIFF
--- a/.config/nvim/lua/plugins/lualine.lua
+++ b/.config/nvim/lua/plugins/lualine.lua
@@ -21,7 +21,7 @@ return {
                 lualine_y = { 'progress' },
                 lualine_z = { 'location' },
             },
-            extensions = { 'nvim-tree', 'lazy', 'mason', 'trouble', 'toggleterm' }
+            extensions = { 'oil', 'lazy', 'mason' }
         }
         require('lualine').setup(config)
     end,


### PR DESCRIPTION
## 概要

Lualineに残っていた未導入プラグイン向けextensionを削除し、実際に利用しているextensionだけに整理します。

## 変更内容

- nvim-tree、trouble、toggleterm extensionを削除
- 導入済みのOil向け公式extensionを追加
- lazy、mason extensionは維持

OilバッファではLualineの専用表示により、現在のディレクトリが表示されます。

## ローカル検証

- git diff --check
- Neovimヘッドレス起動
- Lualineの明示ロードとextension設定値の確認
- pre-commit run --all-files
- コミット時フック

## 制約

GUI上の見た目は手動確認の対象です。