### PR TITLE
ci: 依存関係のEOL検査を追加

### DIFF
--- a/.github/workflows/dependency-eol.yml
+++ b/.github/workflows/dependency-eol.yml
@@ -1,0 +1,31 @@
+name: Check Dependency EOL
+
+on:
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - Brewfile
+      - .config/nvim/**
+      - .config/sheldon/**
+      - .github/workflows/**
+      - .pre-commit-config.yaml
+      - scripts/check-dependency-eol.sh
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-eol:
+    name: Check dependency lifecycle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Reject archived, disabled, or deprecated dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/check-dependency-eol.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ pre-commit run --all-files
 - GitHub Actions変更: actionlint
 - JSON/YAML変更: pre-commitの構文検査
 - Neovim変更: ヘッドレス起動と関連LSP・プラグインの初期化確認
+- 依存関係変更: `GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-eol.sh`
 - セットアップ動作変更: `scripts/smoke-test.sh`を更新し、実行可能な環境では実行する
 
 ローカルでフルセットアップするとユーザー環境を破壊する可能性があるため、`./setup.sh --force`やパッケージ削除は検証目的だけで実行しない。完全セットアップはGitHub Actionsの使い捨てrunnerで検証する。

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ pre-commit run --all-files
 
 スモークテストでは、各CLIの起動、ripgrepとfzfによる検索、tmuxセッション、zoxideのデータベース操作、Bun・Go・Pythonのコード実行、ヘッドレスNeovim上でのTypeScript Language Server接続、標準Markdownパーサーと`render-markdown.nvim`の初期化を確認します。GUI表示とGitHub認証は手動確認の対象です。
 
+依存関係のEOL検査は毎週月曜日と関連ファイルを変更するPull Requestで実行します。Homebrew formulaの`deprecated`・`disabled`、Neovim・Sheldon・pre-commit・GitHub Actionsで利用するGitHubリポジトリの`archived`・`disabled`を検出すると失敗します。ローカルでも次のコマンドで実行できます。
+
+```sh
+GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-eol.sh
+```
+
+更新頻度の低さだけではEOLと判定せず、HomebrewとGitHubが提供する明示的なライフサイクル情報だけを失敗条件にします。
+
 ## ライセンス
 
 [MIT](LICENSE)

--- a/scripts/check-dependency-eol.sh
+++ b/scripts/check-dependency-eol.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+GITHUB_API_URL=${GITHUB_API_URL:-https://api.github.com}
+HOMEBREW_FORMULA_API_URL=${HOMEBREW_FORMULA_API_URL:-https://formulae.brew.sh/api/formula}
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+
+fetch() {
+    local url=$1
+    shift
+    curl --fail --silent --show-error --location --retry 3 "$@" "$url"
+}
+
+is_true() {
+    local field=$1
+    grep -Eq "\"${field}\"[[:space:]]*:[[:space:]]*true"
+}
+
+collect_github_repositories() {
+    {
+        sed -nE "s/^[[:space:]]*[{'\"]?[[:space:]]*['\"]([[:alnum:]_.-]+\/[[:alnum:]_.-]+)['\"].*/\1/p" \
+            "$REPO_ROOT"/.config/nvim/lua/plugins/*.lua
+        sed -nE 's/.*github[[:space:]]*=[[:space:]]*"([[:alnum:]_.-]+\/[[:alnum:]_.-]+)".*/\1/p' \
+            "$REPO_ROOT/.config/sheldon/plugins.toml"
+        sed -nE 's#.*https://github\.com/([[:alnum:]_.-]+/[[:alnum:]_.-]+)(\.git)?.*#\1#p' \
+            "$REPO_ROOT/.pre-commit-config.yaml" \
+            "$REPO_ROOT/.config/nvim/lua/base/lazy.lua"
+        find "$REPO_ROOT/.github/workflows" -type f \( -name '*.yml' -o -name '*.yaml' \) \
+            -exec sed -nE 's/.*uses:[[:space:]]*([[:alnum:]_.-]+\/[[:alnum:]_.-]+)@.*/\1/p' {} +
+    } | sed 's/\.git$//' | sort -u
+}
+
+check_github_repositories() {
+    local repositories_file=$TMP_ROOT/github-repositories.txt
+    local repository response
+    local -a headers=(
+        --header "Accept: application/vnd.github+json"
+        --header "X-GitHub-Api-Version: 2022-11-28"
+    )
+
+    collect_github_repositories > "$repositories_file"
+    if [[ -n ${GITHUB_TOKEN:-} ]]; then
+        headers+=(--header "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+
+    echo "Checking GitHub dependency repositories..."
+    while IFS= read -r repository; do
+        [[ -n $repository ]] || continue
+        if ! response=$(fetch "$GITHUB_API_URL/repos/$repository" "${headers[@]}"); then
+            echo "ERROR: Could not read GitHub repository metadata: $repository" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+
+        if printf '%s' "$response" | is_true archived; then
+            echo "ERROR: GitHub dependency is archived: $repository" >&2
+            failures=$((failures + 1))
+        elif printf '%s' "$response" | is_true disabled; then
+            echo "ERROR: GitHub dependency is disabled: $repository" >&2
+            failures=$((failures + 1))
+        else
+            echo "OK: $repository"
+        fi
+    done < "$repositories_file"
+}
+
+check_homebrew_formulae() {
+    local formula response
+
+    echo "Checking Homebrew formula lifecycle metadata..."
+    while IFS= read -r formula; do
+        [[ -n $formula ]] || continue
+        if ! response=$(fetch "$HOMEBREW_FORMULA_API_URL/$formula.json"); then
+            echo "ERROR: Could not read Homebrew formula metadata: $formula" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+
+        if printf '%s' "$response" | is_true disabled; then
+            echo "ERROR: Homebrew formula is disabled: $formula" >&2
+            failures=$((failures + 1))
+        elif printf '%s' "$response" | is_true deprecated; then
+            echo "ERROR: Homebrew formula is deprecated: $formula" >&2
+            failures=$((failures + 1))
+        else
+            echo "OK: $formula"
+        fi
+    done < <(sed -nE 's/^brew "([^"]+)".*/\1/p' "$REPO_ROOT/Brewfile")
+}
+
+check_github_repositories
+check_homebrew_formulae
+
+if (( failures > 0 )); then
+    echo "Dependency EOL check failed with $failures error(s)." >&2
+    exit 1
+fi
+
+echo "All dependency lifecycle checks passed."


### PR DESCRIPTION
## 概要

依存関係が公式にarchive、disabled、deprecatedとなったことを検出するライフサイクル検査を追加します。更新頻度の低さはEOLと断定せず、明示的なメタデータだけを失敗条件にします。

## 主な変更

- Neovim、Sheldon、pre-commit、GitHub Actionsの依存リポジトリを設定から自動抽出
- GitHub APIでarchived／disabledを検査
- BrewfileのformulaをHomebrew公式APIでdeprecated／disabled検査
- 毎週月曜日、手動実行、関連ファイルを変更するPRで専用CIを実行
- APIエラーも検査失敗として扱い、見逃しを防止
- READMEとAGENTS.mdに実行方法を追加

## ローカル検証

- 現在のGitHub依存28件をライブ検査
- 現在のHomebrew formula 13件をライブ検査
- bash -n scripts/check-dependency-eol.sh
- git diff --check
- pre-commit run --all-files
- コミット時フック

## 制約

初期段階ではGitHubとHomebrewが明示するライフサイクル状態を対象とします。npmのdeprecated情報、脆弱性、公開直後のクールダウン、更新停止のヒューリスティックは今後の拡張対象です。