### PR TITLE
ci: 依存関係にクールダウン期間を適用

### DIFF
--- a/.github/workflows/dependency-eol.yml
+++ b/.github/workflows/dependency-eol.yml
@@ -1,4 +1,4 @@
-name: Check Dependency EOL
+name: Check Dependency Health
 
 on:
   schedule:
@@ -12,7 +12,9 @@ on:
       - .config/sheldon/**
       - .github/workflows/**
       - .pre-commit-config.yaml
+      - packages/bun-lsp/bun.lock
       - scripts/check-dependency-eol.sh
+      - scripts/check-dependency-cooldown.sh
 
 permissions:
   contents: read
@@ -29,3 +31,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./scripts/check-dependency-eol.sh
+
+  dependency-cooldown:
+    name: Check dependency cooldown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Reject dependencies released within the last 7 days
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/check-dependency-cooldown.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ pre-commit run --all-files
 - JSON/YAML変更: pre-commitの構文検査
 - 機微情報: Betterleaksのpre-commit hookとCIの作業ツリー走査を無効化しない。検出除外はユーザーの明示的な承認を必要とする
 - Neovim変更: ヘッドレス起動と関連LSP・プラグインの初期化確認
-- 依存関係変更: `GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-eol.sh`
+- 依存関係変更: `GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-eol.sh`と`GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-cooldown.sh`
 - セットアップ動作変更: `scripts/smoke-test.sh`を更新し、実行可能な環境では実行する
 
 ローカルでフルセットアップするとユーザー環境を破壊する可能性があるため、`./setup.sh --force`やパッケージ削除は検証目的だけで実行しない。完全セットアップはGitHub Actionsの使い捨てrunnerで検証する。

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-eol.sh
 
 更新頻度の低さだけではEOLと判定せず、HomebrewとGitHubが提供する明示的なライフサイクル情報だけを失敗条件にします。
 
+同じCIで、固定済み依存関係に7日間のクールダウンも適用します。pre-commitとGitHub Actionsは参照先コミットの日時、Bunのロックファイル内にあるnpmパッケージは公開日時を検査し、期間内の依存があれば失敗します。ローカルでは次のコマンドを実行します。
+
+```sh
+GITHUB_TOKEN="$(gh auth token)" ./scripts/check-dependency-cooldown.sh
+```
+
+検査期間は`COOLDOWN_DAYS`で変更できます。バージョンを固定していないHomebrewと、ロックファイルだけではリポジトリを一意に特定できないNeovimプラグインは対象外です。
+
 ## ライセンス
 
 [MIT](LICENSE)

--- a/scripts/check-dependency-cooldown.sh
+++ b/scripts/check-dependency-cooldown.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+GITHUB_API_URL=${GITHUB_API_URL:-https://api.github.com}
+NPM_REGISTRY_URL=${NPM_REGISTRY_URL:-https://registry.npmjs.org}
+COOLDOWN_DAYS=${COOLDOWN_DAYS:-7}
+NOW_EPOCH=${NOW_EPOCH:-$(date +%s)}
+
+if ! [[ $COOLDOWN_DAYS =~ ^[0-9]+$ ]]; then
+    echo "ERROR: COOLDOWN_DAYS must be a non-negative integer: $COOLDOWN_DAYS" >&2
+    exit 2
+fi
+if ! [[ $NOW_EPOCH =~ ^[0-9]+$ ]]; then
+    echo "ERROR: NOW_EPOCH must be a non-negative integer: $NOW_EPOCH" >&2
+    exit 2
+fi
+
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+failures=0
+cooldown_seconds=$((COOLDOWN_DAYS * 24 * 60 * 60))
+
+fetch() {
+    local url=$1
+    shift
+    curl --fail --silent --show-error --location --retry 3 "$@" "$url"
+}
+
+to_epoch() {
+    python3 -c 'import datetime, sys; print(int(datetime.datetime.fromisoformat(sys.stdin.read().strip().replace("Z", "+00:00")).timestamp()))'
+}
+
+check_age() {
+    local dependency=$1
+    local published_at=$2
+    local published_epoch age_days
+
+    if ! published_epoch=$(printf '%s' "$published_at" | to_epoch); then
+        echo "ERROR: Could not parse publish time for $dependency: $published_at" >&2
+        failures=$((failures + 1))
+        return
+    fi
+
+    if (( published_epoch > NOW_EPOCH )); then
+        echo "ERROR: Publish time is in the future for $dependency: $published_at" >&2
+        failures=$((failures + 1))
+        return
+    fi
+
+    age_days=$(((NOW_EPOCH - published_epoch) / 86400))
+    if (( NOW_EPOCH - published_epoch < cooldown_seconds )); then
+        echo "ERROR: Dependency is only ${age_days} day(s) old; require ${COOLDOWN_DAYS}: $dependency ($published_at)" >&2
+        failures=$((failures + 1))
+    else
+        echo "OK: $dependency (${age_days} day(s) old)"
+    fi
+}
+
+collect_github_refs() {
+    awk '
+        /^[[:space:]]*-[[:space:]]repo:[[:space:]]https:\/\/github\.com\// {
+            repo = $0
+            sub(/^.*github\.com\//, "", repo)
+            sub(/\.git[[:space:]]*$/, "", repo)
+            next
+        }
+        /^[[:space:]]*rev:/ && repo != "" {
+            ref = $0
+            sub(/^.*rev:[[:space:]]*/, "", ref)
+            print repo "|" ref
+            repo = ""
+        }
+    ' "$REPO_ROOT/.pre-commit-config.yaml"
+
+    find "$REPO_ROOT/.github/workflows" -type f \( -name '*.yml' -o -name '*.yaml' \) \
+        -exec sed -nE 's/.*uses:[[:space:]]*([[:alnum:]_.-]+\/[[:alnum:]_.-]+)@([^[:space:]#]+).*/\1|\2/p' {} +
+}
+
+check_github_refs() {
+    local refs_file=$TMP_ROOT/github-refs.txt
+    local repository ref response published_at
+    local -a headers=(
+        --header "Accept: application/vnd.github+json"
+        --header "X-GitHub-Api-Version: 2022-11-28"
+    )
+
+    collect_github_refs | sort -u > "$refs_file"
+    if [[ -n ${GITHUB_TOKEN:-} ]]; then
+        headers+=(--header "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+
+    echo "Checking GitHub dependency ref ages..."
+    while IFS='|' read -r repository ref; do
+        [[ -n $repository && -n $ref ]] || continue
+        if ! response=$(fetch "$GITHUB_API_URL/repos/$repository/commits/$ref" "${headers[@]}"); then
+            echo "ERROR: Could not read GitHub ref metadata: $repository@$ref" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+
+        if ! published_at=$(printf '%s' "$response" | python3 -c 'import json, sys; print(json.load(sys.stdin)["commit"]["committer"]["date"])'); then
+            echo "ERROR: Could not read commit time for GitHub ref: $repository@$ref" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        check_age "$repository@$ref" "$published_at"
+    done < "$refs_file"
+}
+
+collect_npm_packages() {
+    sed -nE 's/^[[:space:]]*"[^"]+": \["(@?[^"]+)@([^"]+)",.*/\1|\2/p' \
+        "$REPO_ROOT/packages/bun-lsp/bun.lock" | sort -u
+}
+
+check_npm_packages() {
+    local packages_file=$TMP_ROOT/npm-packages.txt
+    local package version response published_at
+
+    collect_npm_packages > "$packages_file"
+    echo "Checking npm package release ages..."
+    while IFS='|' read -r package version; do
+        [[ -n $package && -n $version ]] || continue
+        if ! response=$(fetch "$NPM_REGISTRY_URL/$package"); then
+            echo "ERROR: Could not read npm package metadata: $package@$version" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+
+        if ! published_at=$(printf '%s' "$response" | python3 -c 'import json, sys; version = sys.argv[1]; print(json.load(sys.stdin)["time"][version])' "$version"); then
+            echo "ERROR: Could not read npm publish time: $package@$version" >&2
+            failures=$((failures + 1))
+            continue
+        fi
+        check_age "$package@$version" "$published_at"
+    done < "$packages_file"
+}
+
+check_github_refs
+check_npm_packages
+
+if (( failures > 0 )); then
+    echo "Dependency cooldown check failed with $failures error(s)." >&2
+    exit 1
+fi
+
+echo "All pinned dependencies satisfy the ${COOLDOWN_DAYS}-day cooldown."


### PR DESCRIPTION
## 概要

固定済み依存関係に7日間のクールダウンを適用し、公開直後のバージョンがセットアップへ入ることをCIで防ぎます。

## 主な変更

- pre-commitとGitHub Actionsの参照先コミット日時をGitHub APIで検査
- Bunロックファイル内の直接・推移npm依存の公開日時をnpm registryで検査
- 7日未満の依存、APIエラー、不正な日時を検査失敗として扱う
- COOLDOWN_DAYSで期間を変更可能
- 既存の依存EOL workflowをDependency Healthへ拡張
- README.mdとAGENTS.mdへ実行方法と対象範囲を記載

## ローカル検証

- 7日設定でGitHub固定参照6件とnpm成果物36件が通過
- 30日設定で公開14〜24日の6件が意図どおり拒否されることを確認
- bash -n scripts/check-dependency-cooldown.sh
- pre-commit run --all-files
- ShellCheck、actionlint、YAML検査
- git diff --check

## 制約

バージョンを固定していないHomebrewと、lazy-lock.json単体ではリポジトリを一意に特定できないNeovimプラグインは対象外です。GitHub参照は公開日時を直接取得できないため、参照先コミットのcommitter日時を判定に使用します。