### PR TITLE
fix: ignore Herdr runtime files

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,6 +32,16 @@ jobs:
           grep -q '^brew "bun"' Brewfile
           grep -q '^brew "neovim"' Brewfile
           grep -q '^brew "herdr"' Brewfile
+          for path in \
+            .config/herdr/herdr-client.log \
+            .config/herdr/herdr-server.log \
+            .config/herdr/session.json; do
+            git check-ignore --no-index --quiet "$path"
+          done
+          if git check-ignore --no-index --quiet .config/herdr/config.toml; then
+            echo "Managed Herdr config must not be ignored." >&2
+            exit 1
+          fi
           if grep -q '^brew "tmux"' Brewfile; then
             echo "Brewfile still contains the replaced tmux dependency." >&2
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ nvim/plugin/
 .config/fish/functions
 .config/fish/completions
 .config/fish/conf.d
+# Herdr stores logs, sockets, and session state next to the managed config.
+/.config/herdr/*
+!/.config/herdr/config.toml
 # .config/gh/ is now allowed, but sensitive files should be ignored if needed
 .config/gh/hosts.yml
 fish_variables


### PR DESCRIPTION
## 目的と概要

Herdrがリポジトリ内の.config/herdrへ生成するログ、ソケット、セッション状態をGitの追跡候補から除外します。

## 主な実装内容

- .config/herdr配下を既定でignore
- 管理対象のconfig.tomlだけを追跡可能なまま維持
- 代表的な実行時ファイルとconfig.tomlのignore状態をGitHub Actionsで検証

## ローカル検証

- git diff --check
- pre-commit run --all-files
- pre-commit run actionlint --all-files
- git check-ignore --no-indexによるログ・session.json・config.tomlの確認

## 制約・未検証事項

- Herdrの対話UIには影響しないため、手動UI確認は未実施
- READMEはすでにconfig.tomlのみを管理すると説明しているため変更なし