### PR TITLE
feat: Herdrセッションをディレクトリ名で識別する

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -19,3 +19,7 @@ copy_on_select = true
 prompt_new_tab_name = false
 hide_tab_bar_when_single_tab = false
 sidebar_collapsed_mode = "hidden"
+
+[ui.sidebar.agents]
+# Use the live workspace CWD-derived label instead of the agent kind (for example, codex).
+rows = [["state_icon", "workspace"]]

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,7 +52,7 @@ jobs:
           grep -Eq '^prompt_new_tab_name[[:space:]]*=[[:space:]]*false$' .config/herdr/config.toml
           grep -Eq '^hide_tab_bar_when_single_tab[[:space:]]*=[[:space:]]*false$' .config/herdr/config.toml
           grep -Fq 'rows = [["state_icon", "workspace"]]' .config/herdr/config.toml
-          grep -Fq 'command herdr --session "$(_herdr_session_name)"' .zshrc
+          grep -Fq "command herdr --session \"\$(_herdr_session_name)\"" .zshrc
           if grep -q '^brew "tmux"' Brewfile; then
             echo "Brewfile still contains the replaced tmux dependency." >&2
             exit 1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,7 +78,7 @@ jobs:
           fi
           export PATH="$HOME/.local/bin:$PATH"
 
-          for tool in nvim starship lazygit sheldon gh herdr zoxide fzf go uv bun pre-commit; do
+          for tool in zsh nvim starship lazygit sheldon gh herdr zoxide fzf go uv bun pre-commit; do
             command -v "$tool"
           done
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,6 +51,8 @@ jobs:
           fi
           grep -Eq '^prompt_new_tab_name[[:space:]]*=[[:space:]]*false$' .config/herdr/config.toml
           grep -Eq '^hide_tab_bar_when_single_tab[[:space:]]*=[[:space:]]*false$' .config/herdr/config.toml
+          grep -Fq 'rows = [["state_icon", "workspace"]]' .config/herdr/config.toml
+          grep -Fq 'command herdr --session "$(_herdr_session_name)"' .zshrc
           if grep -q '^brew "tmux"' Brewfile; then
             echo "Brewfile still contains the replaced tmux dependency." >&2
             exit 1

--- a/.zshrc
+++ b/.zshrc
@@ -33,6 +33,25 @@ alias l="ls -lFh"
 alias lg="lazygit"
 alias hr="herdr"
 
+# 引数なしのHerdrは、カレントディレクトリ名の永続セッションへ接続する
+_herdr_session_name() {
+    local session_name="${PWD:t}"
+    session_name="${session_name//[^A-Za-z0-9._-]/-}"
+    session_name="${session_name[1,64]}"
+    if [[ -z "$session_name" || "$session_name" == "." || "$session_name" == ".." ]]; then
+        session_name="herdr"
+    fi
+    print -r -- "$session_name"
+}
+
+herdr() {
+    if (( $# == 0 )); then
+        command herdr --session "$(_herdr_session_name)"
+    else
+        command herdr "$@"
+    fi
+}
+
 
 # Vim Mode
 export KEYTIMEOUT=20
@@ -69,7 +88,7 @@ fi
 
 # Herdr completion
 if command -v herdr &> /dev/null; then
-    eval "$(herdr completion zsh)"
+    eval "$(command herdr completion zsh)"
 fi
 
 # fzf標準連携 (Ctrl-R: 履歴、Ctrl-T: ファイル、Alt-C: ディレクトリ)

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ NeovimプラグインはLazy.nvimで同期します。Markdownを開くと`rende
 
 ### Herdr
 
-WezTermを起動するとHerdrのバックグラウンドセッションを新規作成または再接続します。ほかの端末からは、作業ディレクトリで`herdr`または短縮エイリアスの`hr`を実行して接続できます。設定はtmuxから移行しやすいように`Ctrl-b`プレフィックス、端末のカラーパレット、マウス操作、新しいペインへのカレントディレクトリ継承を使用します。
+WezTermを起動すると、起動時のディレクトリ名を持つHerdrのバックグラウンドセッションを新規作成または再接続します。ほかの端末でも、作業ディレクトリで引数なしの`herdr`または短縮エイリアスの`hr`を実行すると同じ命名規則で接続できます。Herdrの制約に合わせ、ディレクトリ名のASCII英数字、`.`、`_`、`-`以外は`-`へ置換し、64文字に切り詰めます。サブコマンドやオプションを指定した`herdr`は引数を変更せず実行します。設定はtmuxから移行しやすいように`Ctrl-b`プレフィックス、端末のカラーパレット、マウス操作、新しいペインへのカレントディレクトリ継承を使用します。
 
-Herdrのタブバーは常に表示され、クリックで切り替えられます。新しいタブは名前の入力を求めず即座に作成します。macOSでは`Cmd-t`／`Cmd-w`、`Cmd-Shift-[`／`Cmd-Shift-]`、`Cmd-1`〜`Cmd-9`を使用できます。WindowsおよびLinuxでは`Ctrl-Shift-t`／`Ctrl-Shift-w`と`Ctrl-Tab`／`Ctrl-Shift-Tab`を使用できます。これらはWezTermがHerdrのキー操作へ変換し、従来の`Ctrl-b`操作も引き続き利用できます。
+HerdrのAgents欄はagent種別ではなく、各workspaceで動作中のforegroundプロセスのディレクトリ名を表示します。タブバーは常に表示され、クリックで切り替えられます。新しいタブは名前の入力を求めず即座に作成します。macOSでは`Cmd-t`／`Cmd-w`、`Cmd-Shift-[`／`Cmd-Shift-]`、`Cmd-1`〜`Cmd-9`を使用できます。WindowsおよびLinuxでは`Ctrl-Shift-t`／`Ctrl-Shift-w`と`Ctrl-Tab`／`Ctrl-Shift-Tab`を使用できます。これらはWezTermがHerdrのキー操作へ変換し、従来の`Ctrl-b`操作も引き続き利用できます。
 
 主な操作は次のとおりです。
 

--- a/packages/apt.txt
+++ b/packages/apt.txt
@@ -3,3 +3,4 @@ procps
 curl
 file
 git
+zsh

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -56,6 +56,29 @@ HERDR_CONFIG_PATH="$HERDR_TEST_CONFIG" \
 wait "$HERDR_SERVER_PID"
 HERDR_SERVER_PID=""
 
+echo "Checking directory-named Herdr shell launcher..."
+mkdir -p "$TMP_ROOT/bin" "$TMP_ROOT/project name"
+printf '%s\n' \
+    '#!/bin/sh' \
+    "printf '%s\\n' \"\$@\" > \"\$HERDR_ARGS_FILE\"" \
+    > "$TMP_ROOT/bin/herdr"
+chmod +x "$TMP_ROOT/bin/herdr"
+HERDR_ARGS_FILE="$TMP_ROOT/herdr-args.txt" \
+    HERDR_STUB_DIR="$TMP_ROOT/bin" \
+    HERDR_TEST_CWD="$TMP_ROOT/project name" \
+    zsh -lic 'cd "$HERDR_TEST_CWD" && PATH="$HERDR_STUB_DIR:$PATH" herdr'
+test "$(sed -n '1p' "$TMP_ROOT/herdr-args.txt")" = "--session"
+test "$(sed -n '2p' "$TMP_ROOT/herdr-args.txt")" = "project-name"
+test "$(wc -l < "$TMP_ROOT/herdr-args.txt" | tr -d ' ')" = "2"
+
+HERDR_ARGS_FILE="$TMP_ROOT/herdr-args.txt" \
+    HERDR_STUB_DIR="$TMP_ROOT/bin" \
+    zsh -lic 'PATH="$HERDR_STUB_DIR:$PATH" herdr session list --json'
+test "$(sed -n '1p' "$TMP_ROOT/herdr-args.txt")" = "session"
+test "$(sed -n '2p' "$TMP_ROOT/herdr-args.txt")" = "list"
+test "$(sed -n '3p' "$TMP_ROOT/herdr-args.txt")" = "--json"
+test "$(wc -l < "$TMP_ROOT/herdr-args.txt" | tr -d ' ')" = "3"
+
 echo "Checking zoxide database operations..."
 mkdir -p "$TMP_ROOT/zoxide-data" "$TMP_ROOT/project"
 _ZO_DATA_DIR="$TMP_ROOT/zoxide-data" zoxide add "$TMP_ROOT/project"


### PR DESCRIPTION
## 目的と概要

Herdrの新規セッションとAgents欄を、作業中のディレクトリ名で識別できるようにします。

## 主な実装

- 引数なしのherdrおよびhrを、CWD basenameのnamed sessionへ接続
- Herdrの命名制約に合わない文字をハイフンへ正規化し、64文字へ制限
- サブコマンド・オプション付きのherdrは既存どおり透過
- Agents欄をagent種別ではなくworkspaceのCWD由来ラベルで表示
- wrapperの引数とHerdr設定をスモークテスト・CIで検証
- UbuntuへZshを明示的にインストールし、配布する.zshrcを両OSで検証
- READMEの利用方法を更新

## ローカル検証

- git diff --check
- zsh -n .zshrc
- bash -n scripts/smoke-test.sh
- pre-commit run --all-files
- ./scripts/smoke-test.sh（HerdrのPTY/socket作成が必要なためサンドボックス外で実行）
- GITHUB_TOKENを設定したscripts/check-dependency-eol.sh
- GITHUB_TOKENを設定したscripts/check-dependency-cooldown.sh

すべて成功しました。

## 制約・手動確認

未検証事項はありません。ディレクトリ名のASCII英数字、ピリオド、アンダースコア、ハイフン以外はHerdrの制約に合わせてハイフンへ置換します。