### PR TITLE
fix(wezterm): Windowsでタイトルバーを表示する

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -32,7 +32,11 @@ config.win32_system_backdrop        = 'Acrylic'
 config.macos_window_background_blur = 20
 config.initial_cols                 = 188
 config.initial_rows                 = 55
-config.window_decorations           = "RESIZE"
+if wezterm.target_triple:find("windows") then
+    config.window_decorations = "TITLE | RESIZE"
+else
+    config.window_decorations = "RESIZE"
+end
 config.enable_tab_bar               = false
 
 -- カーソルスタイルをバーに設定

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,6 +43,8 @@ jobs:
             exit 1
           fi
           grep -Eq '^config\.enable_tab_bar[[:space:]]*=[[:space:]]*false$' .config/wezterm/wezterm.lua
+          grep -Eq '^    config\.window_decorations = "TITLE \| RESIZE"$' .config/wezterm/wezterm.lua
+          grep -Eq '^    config\.window_decorations = "RESIZE"$' .config/wezterm/wezterm.lua
           grep -q 'exec herdr' .config/wezterm/wezterm.lua
           grep -q 'send_herdr_prefix_key' .config/wezterm/wezterm.lua
           grep -Eq 'key = "T".*mods = "CMD\|SHIFT".*send_herdr_prefix_key\("n", "SHIFT"\)' .config/wezterm/wezterm.lua

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ NeovimプラグインはLazy.nvimで同期します。Markdownを開くと`rende
 
 WezTermを起動するとHerdrのバックグラウンドセッションを新規作成または再接続します。ほかの端末からは、作業ディレクトリで`herdr`または短縮エイリアスの`hr`を実行して接続できます。設定はtmuxから移行しやすいように`Ctrl-b`プレフィックス、端末のカラーパレット、マウス操作、新しいペインへのカレントディレクトリ継承を使用します。
 
+Windows版WezTermではウィンドウをマウスで移動できるようにネイティブタイトルバーを表示します。macOSとLinuxではタイトルバーを非表示にします。
+
 Herdrのタブバーは常に表示され、クリックで切り替えられます。1つのプロジェクトを1つのWorkspaceとして扱い、その中の表示や用途をタブで分けます。新しいタブは名前の入力を求めず即座に作成します。macOSでは`Cmd-t`でタブ、`Cmd-Shift-t`でWorkspaceを作成し、`Cmd-w`、`Cmd-Shift-[`／`Cmd-Shift-]`、`Cmd-1`〜`Cmd-9`も使用できます。WindowsおよびLinuxでは`Ctrl-Shift-t`でタブ、`Ctrl-Shift-n`でWorkspaceを作成し、`Ctrl-Shift-w`と`Ctrl-Tab`／`Ctrl-Shift-Tab`も使用できます。これらはWezTermがHerdrのキー操作へ変換し、従来の`Ctrl-b`操作も引き続き利用できます。
 
 作業ディレクトリと同名のWorkspaceを直接作成する場合は、Zsh関数の`hrw`を使用します。引数を省略するとカレントディレクトリを使い、任意でディレクトリと表示名を指定できます。


### PR DESCRIPTION
## 目的と概要

Windows版WezTermでマウスによるウィンドウ移動を可能にします。

## 主な実装内容

- Windowsでは `window_decorations` に `TITLE | RESIZE` を指定
- macOS/Linuxでは従来どおり `RESIZE` を維持
- CIに両方の装飾設定を検証する回帰チェックを追加
- READMEにOS別のタイトルバー動作を追記

## ローカル検証

- `git diff --check`
- `bash -n setup.sh uninstall.sh scripts/smoke-test.sh`
- `zsh -n .zshrc`
- WezTerm設定のgrep回帰チェック
- `pre-commit run --all-files`
- `./scripts/smoke-test.sh`

## 制約・手動確認

- Windows実機でのタイトルバー表示とドラッグ操作はCI対象外のため、反映後に手動確認が必要です。