### PR TITLE
chore(ci): upgrade checkout action to v7

### DIFF
--- a/.github/workflows/dependency-eol.yml
+++ b/.github/workflows/dependency-eol.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Reject archived, disabled, or deprecated dependencies
         env:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Reject dependencies released within the last 7 days
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate declarations and shell syntax
         shell: bash


### PR DESCRIPTION
## 目的と概要

GitHub Actionsで表示されているNode.js 20廃止警告を解消するため、actions/checkoutをNode.js 24対応のv7へ更新します。

## 主な実装内容

- セットアップ検証ワークフローのactions/checkoutをv4からv7へ更新
- 依存関係ライフサイクル検査とクールダウン検査のactions/checkoutをv4からv7へ更新

## ローカル検証

- git diff --check
- pre-commit run --all-files
- pre-commit run betterleaks-working-tree --hook-stage manual --all-files
- GITHUB_TOKENを設定したscripts/check-dependency-eol.sh
- GITHUB_TOKENを設定したscripts/check-dependency-cooldown.sh

すべて成功しました。actions/checkout@v7は公開から32日経過しており、7日間のクールダウン規則を満たしています。

## 制約・未検証事項

- action自体の実行はGitHub Actions環境でのみ確認可能なため、PR CIでmacOSとUbuntuの完全セットアップを検証します。