### PR TITLE
feat(pkgupd): add cooldown-aware package updates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Validate declarations and shell syntax
         shell: bash
         run: |
-          bash -n setup.sh uninstall.sh
+          bash -n setup.sh uninstall.sh .local/bin/pkgupd scripts/test-pkgupd.sh
           ./setup.sh --help
           ./uninstall.sh --help
           if grep -Eq '^brew "(rust|node|fd)"' Brewfile; then
@@ -96,6 +96,7 @@ jobs:
 
           for path in \
             "$HOME/.zshrc" \
+            "$HOME/.local/bin/pkgupd" \
             "$HOME/.config/herdr/config.toml" \
             "$HOME/.config/starship.toml" \
             "$HOME/.config/nvim" \
@@ -142,6 +143,7 @@ jobs:
           fi
           ./uninstall.sh
           test ! -L "$HOME/.zshrc"
+          test ! -L "$HOME/.local/bin/pkgupd"
           test ! -L "$HOME/.config/nvim"
           brew list --formula neovim
           brew list --formula bun

--- a/.local/bin/pkgupd
+++ b/.local/bin/pkgupd
@@ -1,0 +1,149 @@
+#!/bin/bash
+set -euo pipefail
+
+COOLDOWN_DAYS=${PKGUPD_COOLDOWN_DAYS:-7}
+NOW_EPOCH=${PKGUPD_NOW_EPOCH:-$(date +%s)}
+HOMEBREW_ONLY=0
+
+usage() {
+    cat <<'EOF'
+Usage: pkgupd [--homebrew-only]
+
+Update Homebrew packages after observing the same version for the cooldown period.
+Ubuntu/Debian system packages are updated immediately unless --homebrew-only is used.
+
+Environment:
+  PKGUPD_COOLDOWN_DAYS  Cooldown period in days (default: 7)
+  PKGUPD_NOW_EPOCH      Override the current Unix time for testing
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --homebrew-only)
+            HOMEBREW_ONLY=1
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! [[ $COOLDOWN_DAYS =~ ^[0-9]+$ ]]; then
+    echo "Error: PKGUPD_COOLDOWN_DAYS must be a non-negative integer: $COOLDOWN_DAYS" >&2
+    exit 2
+fi
+if ! [[ $NOW_EPOCH =~ ^[0-9]+$ ]]; then
+    echo "Error: PKGUPD_NOW_EPOCH must be a non-negative integer: $NOW_EPOCH" >&2
+    exit 2
+fi
+command -v brew >/dev/null 2>&1 || { echo "Error: Homebrew not found." >&2; exit 1; }
+command -v bun >/dev/null 2>&1 || { echo "Error: Bun is required to read Homebrew metadata." >&2; exit 1; }
+
+STATE_DIR=${XDG_STATE_HOME:-$HOME/.local/state}/pkgupd
+STATE_FILE=$STATE_DIR/homebrew.tsv
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/pkgupd.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+umask 077
+mkdir -p "$STATE_DIR"
+touch "$STATE_FILE"
+
+OUTDATED_JSON=$TMP_ROOT/outdated.json
+CANDIDATES=$TMP_ROOT/candidates.tsv
+NEXT_STATE=$TMP_ROOT/homebrew.tsv
+ELIGIBLE=$TMP_ROOT/eligible.tsv
+WAITING=$TMP_ROOT/waiting.tsv
+
+echo "Updating Homebrew metadata..."
+brew update
+export HOMEBREW_NO_AUTO_UPDATE=1
+brew outdated --json=v2 > "$OUTDATED_JSON"
+bun -e '
+const data = JSON.parse(await Bun.stdin.text());
+for (const [group, kind] of [["formulae", "formula"], ["casks", "cask"]]) {
+  for (const item of data[group] ?? []) {
+    const name = String(item.name ?? "");
+    const version = String(item.current_version ?? "");
+    if (!name || !version) continue;
+    if (/[\t\r\n]/.test(name + version)) throw new Error("Invalid Homebrew metadata");
+    process.stdout.write(kind + "\t" + name + "\t" + version + "\n");
+  }
+}
+' < "$OUTDATED_JSON" > "$CANDIDATES"
+
+: > "$NEXT_STATE"
+: > "$ELIGIBLE"
+: > "$WAITING"
+COOLDOWN_SECONDS=$((COOLDOWN_DAYS * 24 * 60 * 60))
+awk -F '\t' \
+    -v now="$NOW_EPOCH" \
+    -v cooldown="$COOLDOWN_SECONDS" \
+    -v next_state="$NEXT_STATE" \
+    -v eligible="$ELIGIBLE" \
+    -v waiting="$WAITING" '
+    BEGIN { OFS = "\t" }
+    FILENAME == ARGV[1] {
+        if (NF == 4) first_seen[$1 SUBSEP $2 SUBSEP $3] = $4
+        next
+    }
+    NF == 3 {
+        key = $1 SUBSEP $2 SUBSEP $3
+        seen = key in first_seen ? first_seen[key] : now
+        if (seen > now) seen = now
+        print $1, $2, $3, seen > next_state
+        age = now - seen
+        if (age >= cooldown) {
+            print $1, $2, $3 > eligible
+        } else {
+            remaining = int((cooldown - age + 86399) / 86400)
+            print $1, $2, $3, remaining > waiting
+        }
+    }
+' "$STATE_FILE" "$CANDIDATES"
+mv "$NEXT_STATE" "$STATE_FILE"
+
+if [ -s "$WAITING" ]; then
+    echo "Waiting for Homebrew cooldown:"
+    while IFS=$'\t' read -r kind name version remaining; do
+        printf -- '- %s %s %s (%s day(s) remaining)\n' "$kind" "$name" "$version" "$remaining"
+    done < "$WAITING"
+fi
+
+formulae=()
+casks=()
+while IFS=$'\t' read -r kind name _version; do
+    case "$kind" in
+        formula) formulae+=("$name") ;;
+        cask) casks+=("$name") ;;
+    esac
+done < "$ELIGIBLE"
+
+if [ "${#formulae[@]}" -gt 0 ]; then
+    HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew upgrade --formula "${formulae[@]}"
+fi
+if [ "${#casks[@]}" -gt 0 ]; then
+    HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew upgrade --cask "${casks[@]}"
+fi
+if [ "${#formulae[@]}" -eq 0 ] && [ "${#casks[@]}" -eq 0 ]; then
+    echo "No Homebrew packages are eligible for upgrade."
+fi
+brew cleanup
+
+if [ "$HOMEBREW_ONLY" -eq 0 ] && [ "$(uname -s)" = "Linux" ]; then
+    command -v apt-get >/dev/null 2>&1 || {
+        echo "Error: Linux package updates require apt-get." >&2
+        exit 1
+    }
+    echo "Updating Ubuntu/Debian packages without a cooldown..."
+    sudo apt-get update
+    sudo apt-get upgrade -y
+    sudo apt-get autoremove -y
+    sudo apt-get autoclean
+fi

--- a/.zshrc
+++ b/.zshrc
@@ -60,13 +60,6 @@ export KEYTIMEOUT=20
 bindkey -v
 bindkey -M viins 'jj' vi-cmd-mode
 
-# パッケージマネージャー
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    alias pkgupd='brew update && brew upgrade && brew cleanup && sudo apt update && sudo apt upgrade -y && sudo apt autoremove -y && sudo apt autoclean'
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    alias pkgupd='brew update && brew upgrade && brew cleanup'
-fi
-
 # ユーザー単位でインストールしたCLI
 [ -d "$HOME/.local/bin" ] && export PATH="$HOME/.local/bin:$PATH"
 [ -d "$HOME/bin" ] && export PATH="$HOME/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ $EDITOR ~/.zshrc.local
 
 `~/.zshrc.local`は、このリポジトリによる作成、リンク、削除、Git管理の対象外です。共通設定の後に読み込むため、共通のエイリアスや環境変数をマシンごとに上書きできます。
 
+### パッケージ更新
+
+`pkgupd`はHomebrewの更新候補をローカルで初めて観測してから7日間待ち、同じバージョンが継続しているパッケージだけを更新します。待機中に候補バージョンが変わった場合は、そのバージョンの待機期間を初めから数え直します。観測状態は`${XDG_STATE_HOME:-~/.local/state}/pkgupd/homebrew.tsv`に保存します。
+
+```sh
+pkgupd
+```
+
+UbuntuではHomebrewのみにクールダウンを適用し、APTのシステム・セキュリティ更新は遅延させず従来どおり適用します。Homebrewが対象パッケージのインストールに必要と判断した依存関係は、同時に更新される場合があります。Homebrewだけを処理する場合は`pkgupd --homebrew-only`、待機日数を変更する場合は`PKGUPD_COOLDOWN_DAYS`を使用します。
+
+```sh
+PKGUPD_COOLDOWN_DAYS=14 pkgupd
+```
+
 ## アンインストール
 
 デフォルトでは、このリポジトリが管理するシンボリックリンクだけを削除します。
@@ -119,7 +133,7 @@ pre-commit run --all-files
 
 pre-commitではBetterleaksがステージ済みの変更を走査し、token、APIキー、秘密鍵などの機微情報を検出するとコミットを拒否します。検出結果に機微情報そのものを出力しないよう、redactを有効にしています。CIではpre-commitの回避を考慮し、追跡対象の作業ツリー全体を再走査します。
 
-スモークテストでは、各CLIの起動、ripgrepとfzfによる検索、隔離したHerdrサーバーの起動・接続・停止、zoxideのデータベース操作、Bun・Go・Pythonのコード実行、ヘッドレスNeovim上でのTypeScript Language Server接続、標準Markdownパーサーと`render-markdown.nvim`の初期化を確認します。Herdrの対話UI、GUI表示、GitHub認証は手動確認の対象です。
+スモークテストでは、各CLIの起動、ripgrepとfzfによる検索、隔離したHerdrサーバーの起動・接続・停止、zoxideのデータベース操作、`pkgupd`の候補バージョンと待機期間の判定、Bun・Go・Pythonのコード実行、ヘッドレスNeovim上でのTypeScript Language Server接続、標準Markdownパーサーと`render-markdown.nvim`の初期化を確認します。Herdrの対話UI、GUI表示、GitHub認証は手動確認の対象です。
 
 依存関係のEOL検査は毎週月曜日と関連ファイルを変更するPull Requestで実行します。Homebrew formulaの`deprecated`・`disabled`、Neovim・Sheldon・pre-commit・GitHub Actionsで利用するGitHubリポジトリの`archived`・`disabled`を検出すると失敗します。ローカルでも次のコマンドで実行できます。
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -74,6 +74,9 @@ test "$(_ZO_DATA_DIR="$TMP_ROOT/zoxide-data" zoxide query project)" = "$TMP_ROOT
 echo "Checking Bun execution..."
 test "$(bun -e 'console.log(1 + 1)')" = "2"
 
+echo "Checking package update cooldown..."
+./scripts/test-pkgupd.sh
+
 echo "Checking Go compilation and execution..."
 printf 'package main\nimport "fmt"\nfunc main() { fmt.Print("ok") }\n' > "$TMP_ROOT/main.go"
 test "$(go run "$TMP_ROOT/main.go")" = "ok"

--- a/scripts/test-pkgupd.sh
+++ b/scripts/test-pkgupd.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+TMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/pkgupd-test.XXXXXX")
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+FAKE_BIN=$TMP_ROOT/bin
+STATE_HOME=$TMP_ROOT/state
+BREW_LOG=$TMP_ROOT/brew.log
+OUTDATED_JSON=$TMP_ROOT/outdated.json
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/brew" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$PKGUPD_TEST_BREW_LOG"
+if [ "$1" = "outdated" ]; then
+    cat "$PKGUPD_TEST_OUTDATED_JSON"
+fi
+EOF
+chmod +x "$FAKE_BIN/brew"
+
+write_outdated() {
+    local formula_version=$1
+    local cask_version=$2
+    printf '{"formulae":[{"name":"demo-formula","current_version":"%s"}],"casks":[{"name":"demo-cask","current_version":"%s"}]}\n' \
+        "$formula_version" "$cask_version" > "$OUTDATED_JSON"
+}
+
+run_pkgupd() {
+    local now_epoch=$1
+    PATH="$FAKE_BIN:$PATH" \
+        XDG_STATE_HOME="$STATE_HOME" \
+        PKGUPD_COOLDOWN_DAYS=7 \
+        PKGUPD_NOW_EPOCH="$now_epoch" \
+        PKGUPD_TEST_BREW_LOG="$BREW_LOG" \
+        PKGUPD_TEST_OUTDATED_JSON="$OUTDATED_JSON" \
+        "$REPO_ROOT/.local/bin/pkgupd" --homebrew-only >/dev/null
+}
+
+write_outdated 2.0.0 3.0.0
+run_pkgupd 100000
+if grep -q '^upgrade ' "$BREW_LOG"; then
+    echo "pkgupd upgraded a newly observed version." >&2
+    exit 1
+fi
+
+: > "$BREW_LOG"
+run_pkgupd $((100000 + 7 * 86400 - 1))
+if grep -q '^upgrade ' "$BREW_LOG"; then
+    echo "pkgupd upgraded before the cooldown elapsed." >&2
+    exit 1
+fi
+
+write_outdated 2.1.0 3.1.0
+: > "$BREW_LOG"
+run_pkgupd $((100000 + 7 * 86400))
+if grep -q '^upgrade ' "$BREW_LOG"; then
+    echo "pkgupd did not reset the cooldown for a new target version." >&2
+    exit 1
+fi
+
+: > "$BREW_LOG"
+run_pkgupd $((100000 + 14 * 86400))
+grep -q '^upgrade --formula demo-formula$' "$BREW_LOG"
+grep -q '^upgrade --cask demo-cask$' "$BREW_LOG"
+
+echo "pkgupd cooldown tests passed."

--- a/setup.sh
+++ b/setup.sh
@@ -94,6 +94,7 @@ remove_legacy_tmux_symlink() {
 create_symlinks() {
     local dotfile_sources=(
         "$REPO_ROOT/.zshrc"
+        "$REPO_ROOT/.local/bin/pkgupd"
         "$REPO_ROOT/.config/herdr/config.toml"
         "$REPO_ROOT/.config/starship.toml"
         "$REPO_ROOT/.config/nvim"
@@ -104,6 +105,7 @@ create_symlinks() {
     )
     local dotfile_dests=(
         "$HOME/.zshrc"
+        "$HOME/.local/bin/pkgupd"
         "$HOME/.config/herdr/config.toml"
         "$HOME/.config/starship.toml"
         "$HOME/.config/nvim"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -29,6 +29,7 @@ remove_symlinks() {
     local dotfile_paths=(
         .zshrc
         .tmux.conf
+        .local/bin/pkgupd
         .config/herdr/config.toml
         .config/starship.toml
         .config/nvim


### PR DESCRIPTION
## 目的と概要

pkgupdがHomebrewの更新候補を即時適用していたため、候補バージョンをローカルで初めて観測してから7日間待ち、同じバージョンが継続しているパッケージだけを更新するようにします。

## 主な実装内容

- pkgupdをZshエイリアスから~/.local/binの実行可能コマンドへ変更
- formulaとcaskの候補バージョン・初回観測時刻をXDG stateへ保存
- 7日経過した候補のみを明示指定してbrew upgrade
- 候補バージョン変更時にクールダウンをリセット
- UbuntuのAPT更新はセキュリティ修正を遅らせず即時適用
- --homebrew-onlyとPKGUPD_COOLDOWN_DAYSを追加
- セットアップ、アンインストール、README、CI検証を更新
- 初回観測、期限直前、候補変更、期限到達の状態遷移テストを追加

## ローカル検証

- bash -n setup.sh uninstall.sh .local/bin/pkgupd scripts/test-pkgupd.sh scripts/smoke-test.sh
- zsh -n .zshrc
- ./.local/bin/pkgupd --help
- ./scripts/test-pkgupd.sh
- ./scripts/smoke-test.sh
- git diff --check
- pre-commit run --all-files
- pre-commit run --files .local/bin/pkgupd scripts/test-pkgupd.sh
- pre-commit run betterleaks-working-tree --hook-stage manual --all-files

すべて成功しました。

## 制約・未検証事項

- 初回実行は候補の観測だけを行い、Homebrewパッケージは更新しません。
- Homebrewが対象パッケージのインストールに必要と判断した推移的依存関係は同時更新される場合があります。
- APT更新には従来どおりsudo権限が必要です。